### PR TITLE
docs(readme): add 'Verify server is running' step (Fixes #1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ SecureFileManager is a Node.js application designed to manage files with support
   ```sh
   npm run start-worker
   ```
+### Verify it’s running
+In a new terminal, hit the status endpoint (adjust port if the console shows a different one):
+```bash
+curl http://localhost:5000/status
 
 ## Project Structure
 - `server.js`: Entry point for the Express server

--- a/README.md
+++ b/README.md
@@ -41,11 +41,10 @@ SecureFileManager is a Node.js application designed to manage files with support
   npm run start-worker
   ```
 ### Verify it’s running
-In a new terminal, hit the status endpoint (adjust port if the console shows a different one):
+- In a new terminal, hit the status endpoint (adjust port if the console shows a different one):
 ```bash
-```
 curl http://localhost:5000/status
-
+```
 ## Project Structure
 - `server.js`: Entry point for the Express server
 - `main.js`: Initial connection and statistics test script
@@ -66,3 +65,4 @@ Pull requests and issues are welcome. Please open an issue to discuss any major 
 
 ## License
 This project is licensed under the ISC License.
+ ```

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ SecureFileManager is a Node.js application designed to manage files with support
 ### Verify it’s running
 In a new terminal, hit the status endpoint (adjust port if the console shows a different one):
 ```bash
+```
 curl http://localhost:5000/status
 
 ## Project Structure


### PR DESCRIPTION
Add a tiny “Verify it’s running” step under *Running the Server* with a curl to /status.